### PR TITLE
Fix: #6. Bump openai to 1.3.9

### DIFF
--- a/requirements.debian.txt
+++ b/requirements.debian.txt
@@ -13,7 +13,7 @@ lxml
 matplotlib
 nltk
 numpy
-openai
+openai==1.3.9
 openpyxl
 pandas==1.5.3
 Pillow


### PR DESCRIPTION
## This PR

- bumps openai